### PR TITLE
Fix support for Gradle Configuration Cache

### DIFF
--- a/realm-transformer/src/main/kotlin/io/realm/analytics/RealmAnalytics.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/analytics/RealmAnalytics.kt
@@ -15,15 +15,7 @@
  */
 package io.realm.analytics
 
-import io.realm.transformer.CONNECT_TIMEOUT
-import io.realm.transformer.READ_TIMEOUT
-import io.realm.transformer.Utils
-import io.realm.transformer.ext.getAgpVersion
-import io.realm.transformer.ext.getAppId
-import io.realm.transformer.ext.getMinSdk
-import io.realm.transformer.ext.getTargetSdk
-import org.gradle.api.Project
-import org.gradle.api.artifacts.ResolvedArtifact
+import io.realm.transformer.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.Executors
@@ -88,67 +80,27 @@ class RealmAnalytics {
         }
     }
 
-    public fun calculateAnalyticsData(project: Project): Boolean {
-        if (!isAnalyticsEnabled(project))  {
+    fun calculateAnalyticsData(metadata: ProjectMetaData): Boolean {
+        if (!isAnalyticsEnabled(metadata.isGradleOffline))  {
             return false
         }
 
-        // Language specific data
-        // Should be safe to iterate the configurations as we are way beyond the configuration
-        // phase
-        var containsKotlin = false
-        outer@
-        for (conf in project.configurations) {
-            try {
-                for (artifact: ResolvedArtifact in conf.resolvedConfiguration.resolvedArtifacts) {
-                    if (artifact.name.startsWith("kotlin-stdlib")) {
-                        containsKotlin = true
-                        break@outer
-                    }
-                }
-            } catch (ignore: Exception) {
-                // Some artifacts might not be able to resolve, in this case, just ignore them.
-            }
-        }
-
-        // Android specific data
-        val appId: String = project.getAppId()
-        val targetSdk: String = project.getTargetSdk()
-        val minSdk: String = project.getMinSdk()
-        val target =
-            when {
-                project.plugins.findPlugin("com.android.application") != null -> {
-                    "app"
-                }
-                project.plugins.findPlugin("com.android.library") != null -> {
-                    "library"
-                }
-                else -> {
-                    "unknown"
-                }
-            }
-        val gradleVersion = project.gradle.gradleVersion
-        val agpVersion = project.getAgpVersion()
-
-        // Realm specific data
-        val sync: Boolean = Utils.isSyncEnabled(project)
-
         data = AnalyticsData(
-            appId = PublicAppId(appId),
-            usesKotlin = containsKotlin,
-            usesSync = sync,
-            targetSdk = targetSdk,
-            minSdk = minSdk,
-            target = target,
-            gradleVersion = gradleVersion,
-            agpVersion = agpVersion
+            appId = PublicAppId(metadata.appId),
+            usesKotlin = metadata.usesKotlin,
+            usesSync = metadata.usesSync,
+            targetSdk = metadata.targetSdk,
+            minSdk = metadata.minSdk,
+            target = metadata.targetType,
+            gradleVersion = metadata.gradleVersion,
+            agpVersion = metadata.agpVersion
         )
         return true
     }
 
-    private fun isAnalyticsEnabled(project: Project): Boolean {
+    private fun isAnalyticsEnabled(isOffline: Boolean): Boolean {
         val env = System.getenv()
-        return !project.gradle.startParameter.isOffline
+        return !isOffline
                 && env["REALM_DISABLE_ANALYTICS"] == null
                 && env["CI"] == null
     }

--- a/realm-transformer/src/main/kotlin/io/realm/analytics/RealmAnalytics.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/analytics/RealmAnalytics.kt
@@ -15,7 +15,9 @@
  */
 package io.realm.analytics
 
-import io.realm.transformer.*
+import io.realm.transformer.ProjectMetaData
+import io.realm.transformer.CONNECT_TIMEOUT
+import io.realm.transformer.READ_TIMEOUT
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.Executors

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
@@ -18,17 +18,21 @@ package io.realm.transformer
 
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.internal.publishing.AndroidArtifacts
+import io.realm.analytics.RealmAnalytics
 import io.realm.transformer.build.BuildTemplate
 import io.realm.transformer.build.FullBuild
-import io.realm.transformer.ext.getBootClasspath
+import io.realm.transformer.ext.*
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
@@ -47,18 +51,37 @@ val READ_TIMEOUT = 2000L;
 
 // Wrapper for storing data from org.gradle.api.Project as we cannot store a class variable to it
 // as that conflict with the Configuration Cache.
-data class ProjectMetaData(val bootClassPath: Set<File>)
+data class ProjectMetaData(
+        val bootClassPath: Set<File>,
+        val usesKotlin: Boolean,
+        val targetType: String,
+        val targetSdk: String,
+        val minSdk: String,
+        val agpVersion: String,
+        val appId: String,
+        val gradleVersion: String,
+        val usesSync: Boolean,
+        val isGradleOffline: Boolean) {
+}
 
 /**
  * This class implements the Transform API provided by the Android Gradle plugin.
  */
-class RealmTransformer(bootClasspath: ConfigurableFileCollection,
+class RealmTransformer(private val metadata: ProjectMetaData,
                        private val inputs: ListProperty<Directory>,
                        private val allJars: ListProperty<RegularFile>,
                        private val referencedInputs: ConfigurableFileCollection,
                        private val output: RegularFileProperty) {
 
-    private val metadata = ProjectMetaData(bootClassPath = bootClasspath.files)
+    private val analytics: RealmAnalytics? = try {
+        val analytics = RealmAnalytics()
+        analytics.calculateAnalyticsData(metadata)
+        analytics
+    } catch (e: Exception) {
+        // Analytics should never crash the build.
+        logger.debug("Could not calculate Realm analytics data:\n$e")
+        null
+    }
 
     companion object {
 
@@ -78,6 +101,15 @@ class RealmTransformer(bootClasspath: ConfigurableFileCollection,
                                 )
                             }.files)
                             it.bootClasspath.setFrom(project.getBootClasspath())
+                            it.offline.set(project.gradle.startParameter.isOffline)
+                            it.targetType.set(project.targetType())
+                            it.usesKotlin.set(project.usesKotlin())
+                            it.minSdk.set(project.getMinSdk())
+                            it.targetSdk.set(project.getTargetSdk())
+                            it.agpVersion.set(project.getAgpVersion())
+                            it.usesSync.set(Utils.isSyncEnabled(project))
+                            it.gradleVersion.set(project.gradle.gradleVersion)
+                            it.appId.set(project.getAppId())
                         }
                     component.artifacts.forScope(com.android.build.api.variant.ScopedArtifacts.Scope.PROJECT)
                         .use<ModifyClassesTask>(taskProvider)
@@ -89,6 +121,29 @@ class RealmTransformer(bootClasspath: ConfigurableFileCollection,
                         )
                 }
             }
+        }
+
+        private fun Project.targetType(): String = with(project.plugins) {
+            when {
+                findPlugin("com.android.application") != null -> "app"
+                findPlugin("com.android.library") != null -> "library"
+                else -> "unknown"
+            }
+        }
+
+        private fun Project.usesKotlin(): Boolean {
+            for (conf in project.configurations) {
+                try {
+                    for (artifact: ResolvedArtifact in conf.resolvedConfiguration.resolvedArtifacts) {
+                        if (artifact.name.startsWith("kotlin-stdlib")) {
+                            return true
+                        }
+                    }
+                } catch (ignore: Exception) {
+                    // Some artifacts might not be able to resolve, in this case, just ignore them.
+                }
+            }
+            return false
         }
     }
 
@@ -140,10 +195,12 @@ class RealmTransformer(bootClasspath: ConfigurableFileCollection,
 
     private fun exitTransform(timer: Stopwatch) {
         timer.stop()
+        analytics?.execute()
     }
 }
 
 abstract class ModifyClassesTask: DefaultTask() {
+
     @get:Classpath
     abstract val fullRuntimeClasspath : ConfigurableFileCollection
 
@@ -156,12 +213,57 @@ abstract class ModifyClassesTask: DefaultTask() {
     @get:InputFiles
     abstract val bootClasspath: ConfigurableFileCollection
 
+    @get:Input
+    abstract val targetType: Property<String>
+
+    @get:Input
+    abstract val offline: Property<Boolean>
+
+    @get:Input
+    abstract val usesKotlin: Property<Boolean>
+
+    @get:Input
+    abstract val targetSdk: Property<String>
+
+    @get:Input
+    abstract val minSdk: Property<String>
+
+    @get:Input
+    abstract val agpVersion: Property<String>
+
+    @get:Input
+    abstract val appId: Property<String>
+
+    @get:Input
+    abstract val gradleVersion: Property<String>
+
+    @get:Input
+    abstract val usesSync: Property<Boolean>
+
     @get:OutputFiles
     abstract val output: RegularFileProperty
 
     @TaskAction
     fun taskAction() {
-        RealmTransformer(bootClasspath, allDirectories, allJars, fullRuntimeClasspath, output).transform()
+        val metadata = ProjectMetaData(
+                bootClassPath = bootClasspath.files,
+                usesKotlin = usesKotlin.get(),
+                targetType = targetType.get(),
+                targetSdk = targetSdk.get(),
+                minSdk = minSdk.get(),
+                agpVersion = agpVersion.get(),
+                appId = appId.get(),
+                gradleVersion = gradleVersion.get(),
+                usesSync = usesSync.get(),
+                isGradleOffline = offline.get()
+        )
+        RealmTransformer(
+                metadata = metadata,
+                inputs = allDirectories,
+                allJars = allJars,
+                referencedInputs = fullRuntimeClasspath,
+                output = output
+        ).transform()
     }
 }
 

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/RealmTransformer.kt
@@ -21,7 +21,11 @@ import com.android.build.gradle.internal.publishing.AndroidArtifacts
 import io.realm.analytics.RealmAnalytics
 import io.realm.transformer.build.BuildTemplate
 import io.realm.transformer.build.FullBuild
-import io.realm.transformer.ext.*
+import io.realm.transformer.ext.getTargetSdk
+import io.realm.transformer.ext.getMinSdk
+import io.realm.transformer.ext.getBootClasspath
+import io.realm.transformer.ext.getAppId
+import io.realm.transformer.ext.getAgpVersion
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ResolvedArtifact

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/ext/ProjectExt.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/ext/ProjectExt.kt
@@ -43,24 +43,10 @@ fun Project.getTargetSdk(): String {
 }
 
 /**
- * Returns the `targetSdk` property for this project if it is available.
- */
-fun Project.getTargetSdkOrNull(): String? {
-    return getAndroidExtension(this).defaultConfig.targetSdkVersion?.apiString
-}
-
-/**
  * Returns the `minSdk` property for this project if it is available.
  */
 fun Project.getMinSdk(): String {
     return getAndroidExtension(this).defaultConfig.minSdkVersion?.apiString ?: "unknown"
-}
-
-/**
- * Returns the `minSdk` property for this project if it is available.
- */
-fun Project.getMinSdkOrNull(): String? {
-    return getAndroidExtension(this).defaultConfig.minSdkVersion?.apiString
 }
 
 /**
@@ -95,43 +81,6 @@ fun Project.getAgpVersion(): String {
  */
 fun Project.getBootClasspath(): List<File> {
     return getAndroidExtension(this).bootClasspath
-}
-
-fun Project.getAndroidJar(): ConfigurableFileCollection {
-    val sdk = getTargetSdkOrNull() ?: error("Unable to find Android SDK version")
-    return project.files("${findAndroidSdkLocation()}/platforms/android-$sdk/android.jar")
-}
-
-fun Project.findAndroidSdkLocation(): File {
-    val localProperties = File(rootDir, "local.properties")
-    if (localProperties.exists()) {
-        val properties = Properties()
-        FileInputStream(localProperties).use { instr ->
-            properties.load(instr)
-        }
-        var sdkDirProp = properties.getProperty("sdk.dir")
-        return if (sdkDirProp != null) {
-            File(sdkDirProp)
-        } else {
-            sdkDirProp = properties.getProperty("android.dir")
-            if (sdkDirProp != null) {
-                File(rootDir, sdkDirProp)
-            } else {
-                error("No sdk.dir property defined in local.properties file.")
-            }
-        }
-    } else {
-        val envVar = System.getenv("ANDROID_HOME")
-        if (envVar != null) {
-            return File(envVar)
-        } else {
-            val property = System.getProperty("android.home")
-            if (property != null) {
-                return File(property)
-            }
-        }
-    }
-    error("Can't find SDK path")
 }
 
 private fun getAndroidExtension(project: Project): BaseExtension {

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/ext/ProjectExt.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/ext/ProjectExt.kt
@@ -18,7 +18,10 @@ package io.realm.transformer.ext
 
 import com.android.build.gradle.BaseExtension
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import java.io.File
+import java.io.FileInputStream
+import java.util.*
 
 /**
  * Attempts to determine the best possible unique AppId for this project.
@@ -40,10 +43,24 @@ fun Project.getTargetSdk(): String {
 }
 
 /**
+ * Returns the `targetSdk` property for this project if it is available.
+ */
+fun Project.getTargetSdkOrNull(): String? {
+    return getAndroidExtension(this).defaultConfig.targetSdkVersion?.apiString
+}
+
+/**
  * Returns the `minSdk` property for this project if it is available.
  */
 fun Project.getMinSdk(): String {
     return getAndroidExtension(this).defaultConfig.minSdkVersion?.apiString ?: "unknown"
+}
+
+/**
+ * Returns the `minSdk` property for this project if it is available.
+ */
+fun Project.getMinSdkOrNull(): String? {
+    return getAndroidExtension(this).defaultConfig.minSdkVersion?.apiString
 }
 
 /**
@@ -78,6 +95,43 @@ fun Project.getAgpVersion(): String {
  */
 fun Project.getBootClasspath(): List<File> {
     return getAndroidExtension(this).bootClasspath
+}
+
+fun Project.getAndroidJar(): ConfigurableFileCollection {
+    val sdk = getTargetSdkOrNull() ?: error("Unable to find Android SDK version")
+    return project.files("${findAndroidSdkLocation()}/platforms/android-$sdk/android.jar")
+}
+
+fun Project.findAndroidSdkLocation(): File {
+    val localProperties = File(rootDir, "local.properties")
+    if (localProperties.exists()) {
+        val properties = Properties()
+        FileInputStream(localProperties).use { instr ->
+            properties.load(instr)
+        }
+        var sdkDirProp = properties.getProperty("sdk.dir")
+        return if (sdkDirProp != null) {
+            File(sdkDirProp)
+        } else {
+            sdkDirProp = properties.getProperty("android.dir")
+            if (sdkDirProp != null) {
+                File(rootDir, sdkDirProp)
+            } else {
+                error("No sdk.dir property defined in local.properties file.")
+            }
+        }
+    } else {
+        val envVar = System.getenv("ANDROID_HOME")
+        if (envVar != null) {
+            return File(envVar)
+        } else {
+            val property = System.getProperty("android.home")
+            if (property != null) {
+                return File(property)
+            }
+        }
+    }
+    error("Can't find SDK path")
 }
 
 private fun getAndroidExtension(project: Project): BaseExtension {

--- a/realm-transformer/src/main/kotlin/io/realm/transformer/ext/ProjectExt.kt
+++ b/realm-transformer/src/main/kotlin/io/realm/transformer/ext/ProjectExt.kt
@@ -18,10 +18,7 @@ package io.realm.transformer.ext
 
 import com.android.build.gradle.BaseExtension
 import org.gradle.api.Project
-import org.gradle.api.file.ConfigurableFileCollection
 import java.io.File
-import java.io.FileInputStream
-import java.util.*
 
 /**
  * Attempts to determine the best possible unique AppId for this project.


### PR DESCRIPTION
## Description
This PR fixes Gradle Configuration Cache support of Realm Gradle Plugin.

### Problem
Currently, the `-transform-api` versions of Realm do not support Gradle Configuration Cache. The reason is that `ModifyClassesTask` class in Realm Gradle Plugin uses a reference to `Project` object which is something that is now allowed by Config Cache. The build fails with the error below:
```
4 problems were found storing the configuration cache.
- Task `:app:debugRealmAccessorsTransformer` of type `io.realm.transformer.ModifyClassesTask`: invocation of 'Task.project' at execution time is unsupported.
  See https://docs.gradle.org/7.5.1/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
- Task `:features:feature.reservation:debugRealmAccessorsTransformer` of type `io.realm.transformer.ModifyClassesTask`: invocation of 'Task.project' at execution time is unsupported.
  See https://docs.gradle.org/7.5.1/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
- Task `:legacy:debugRealmAccessorsTransformer` of type `io.realm.transformer.ModifyClassesTask`: invocation of 'Task.project' at execution time is unsupported.
  See https://docs.gradle.org/7.5.1/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
- Task `:libraries:lib.data:debugRealmAccessorsTransformer` of type `io.realm.transformer.ModifyClassesTask`: invocation of 'Task.project' at execution time is unsupported.
  See https://docs.gradle.org/7.5.1/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
```
### Solution
The solution is to move all of the usages of `Project` object out of the Gradle task at the registration phase. This way, Configuration cache works as expected.